### PR TITLE
layout-margin/layout-padding won't work with flex variants #1281

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -31,6 +31,33 @@
   margin: $layout-gutter-width / 2;
 }
 
+[layout-padding],
+[layout-padding] > [flex-md] {
+  padding: $layout-gutter-width / 2;
+}
+[layout-margin],
+[layout-margin] > [flex-md] {
+  margin: $layout-gutter-width / 2;
+}
+
+[layout-padding],
+[layout-padding] > [flex-sm] {
+  padding: $layout-gutter-width / 3;
+}
+[layout-margin],
+[layout-margin] > [flex-sm] {
+  margin: $layout-gutter-width / 3;
+}
+
+[layout-padding],
+[layout-padding] > [flex-lg] {
+  padding: $layout-gutter-width;
+}
+[layout-margin],
+[layout-margin] > [flex-lg] {
+  margin: $layout-gutter-width;
+}
+
 [layout-wrap] {
   flex-wrap: wrap;
 }


### PR DESCRIPTION
Added different padding and margins for flex-sm, flex-md and flex-lg
To fix issue #1281 (layout-margin/layout-padding won't work with flex variants)

flex-lg = $layout-gutter-width
flex-md = $layout-gutter-width /2
flex-sm = $layout-gutter-width/3
